### PR TITLE
Add CSS style sheet with @font-face declaration

### DIFF
--- a/webfonts/LeagueScriptNumberOne.css
+++ b/webfonts/LeagueScriptNumberOne.css
@@ -1,0 +1,18 @@
+/*
+  'League Script Number One'
+  https://www.theleagueofmoveabletype.com/league-script-number-one
+
+  Copyright (c) 2008, Haley Fiege <haley@kingdomofawesome.com>,
+  with Reserved Font Name: "League Script".
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  This license is copied below, and is also available with a FAQ at:
+  http://scripts.sil.org/OFL
+*/
+@font-face {
+  font-family: 'League Script Number One';
+  src: url('LeagueScriptNumberOne-webfont.eot?#iefix') format('embedded-opentype'),
+       url('LeagueScriptNumberOne-webfont.woff') format('woff'),
+       url('LeagueScriptNumberOne-webfont.ttf')  format('truetype'),
+       url('LeagueScriptNumberOne-webfont.svg#webfontvrSlvBea') format('svg');
+}

--- a/webfonts/LeagueScriptNumberOne.css
+++ b/webfonts/LeagueScriptNumberOne.css
@@ -11,7 +11,7 @@
 */
 @font-face {
   font-family: 'League Script Number One';
-  src: url('LeagueScriptNumberOne-webfont.eot'),
+  src: url('LeagueScriptNumberOne-webfont.eot');
   src: url('LeagueScriptNumberOne-webfont.eot?#iefix') format('embedded-opentype'),
        url('LeagueScriptNumberOne-webfont.woff') format('woff'),
        url('LeagueScriptNumberOne-webfont.ttf')  format('truetype'),

--- a/webfonts/LeagueScriptNumberOne.css
+++ b/webfonts/LeagueScriptNumberOne.css
@@ -11,6 +11,7 @@
 */
 @font-face {
   font-family: 'League Script Number One';
+  src: url('LeagueScriptNumberOne-webfont.eot'),
   src: url('LeagueScriptNumberOne-webfont.eot?#iefix') format('embedded-opentype'),
        url('LeagueScriptNumberOne-webfont.woff') format('woff'),
        url('LeagueScriptNumberOne-webfont.ttf')  format('truetype'),


### PR DESCRIPTION
The format used for the @font-face declaration is the
"Fontspring @Font-Face Syntax"[1] considered [2]
"the most simple and compatible one".

[1] The New Bulletproof @Font-Face Syntax
2011-02-03 (last updated: 2011-04-21)
http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax

[2] The @Font-Face Rule And Useful Web Font Tricks
2011-03-02, by Ralf Hermann
http://www.smashingmagazine.com/2011/03/02/the-font-face-rule-revisited-and-useful-tricks/
